### PR TITLE
ユーザモデルを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,8 @@ AllCops:
     - tmp/**/*
     - log/**/*
     - public/**/*
+
+RSpec/NestedGroups:
+  Max: 4
+  Include:
+    - spec/models/*

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 group :development, :test do
   gem 'brakeman', '~> 6.0', require: false
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'faker', '~> 3.2'
   gem 'katakata_irb', github: 'tompng/katakata_irb', require: false
   gem 'rbs', '~> 3.1', require: false
   gem 'rbs_rails', '~> 0.12', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.2.0)
+      i18n (>= 1.8.11, < 2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
@@ -262,6 +264,7 @@ DEPENDENCIES
   brakeman (~> 6.0)
   debug
   factory_bot_rails (~> 6.2)
+  faker (~> 3.2)
   katakata_irb!
   pg (~> 1.5)
   puma (~> 6.3)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
+  validates :sessionid, uniqueness: true
+  validates :access_token, presence: true, uniqueness: true
+
+  has_secure_token :sessionid
+end

--- a/db/migrate/20230710104816_enable_citext_extension.rb
+++ b/db/migrate/20230710104816_enable_citext_extension.rb
@@ -1,0 +1,5 @@
+class EnableCitextExtension < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'citext'
+  end
+end

--- a/db/migrate/20230710104825_create_users.rb
+++ b/db/migrate/20230710104825_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.citext :email, null: false, index: { unique: true }
+      t.string :sessionid, null: false, index: { unique: true }
+      t.string :access_token, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_10_104825) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.citext "email", null: false
+    t.string "sessionid", null: false
+    t.string "access_token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["access_token"], name: "index_users_on_access_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["sessionid"], name: "index_users_on_sessionid", unique: true
+  end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe '#save' do
+    subject { user.save }
+
+    let(:user) { described_class.new email:, access_token: }
+    let(:email) { Faker::Internet.email }
+    let(:access_token) { Faker::Alphanumeric.alphanumeric }
+
+    context 'パラメータが正当であるとき' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'email' do
+      context 'フォーマットが正しくないとき' do
+        let(:email) { 'foo.com' }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context '同じメールアドレスを持つユーザが存在するとき' do
+        before do
+          described_class.create! email:, access_token: Faker::Alphanumeric.alphanumeric
+        end
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context 'sessionid' do
+      context '値が設定されていないとき' do
+        it { is_expected.to be_truthy }
+
+        it 'セッションIDが自動的に設定される' do
+          expect { subject }.to change(user, :sessionid).from(nil).to String
+        end
+      end
+
+      context '同じセッションIDを持つユーザが存在するとき' do
+        let(:user) { described_class.new email:, sessionid:, access_token: }
+        let(:sessionid) { Faker::Alphanumeric.alphanumeric }
+
+        before do
+          described_class.create! email: Faker::Internet.email,
+                                  sessionid:, access_token: Faker::Alphanumeric.alphanumeric
+        end
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context 'access_token' do
+      context '値が設定されていないとき' do
+        let(:access_token) { nil }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context '同じアクセストークンを持つユーザが存在するとき' do
+        before do
+          described_class.create! email: Faker::Internet.email, access_token:
+        end
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+
+  describe '#find_by' do
+    context 'email' do
+      subject { described_class.find_by! email: email.upcase }
+
+      let(:email) { Faker::Internet.email }
+      let(:access_token) { Faker::Alphanumeric.alphanumeric }
+
+      before do
+        described_class.create! email:, access_token:
+      end
+
+      context '大文字小文字違いのメールアドレスで検索するとき' do
+        it '同一のレコードを発見する' do
+          expect(subject).to eq described_class.find_by! email: email.downcase
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要

ユーザおよびユーザセッションを表現するモデルであるUserを追加する。

## セッションID属性およびアクセストークン属性

この2つの属性のペアによってユーザセッションを識別する。具体的には、ブラウザと本クライアント間のセッション、および本クライアントとAPIサーバ間のセッションを結びつける。そして今回のアプリであれば、その結びつけさえできればアプリとしては機能する。

## メールアドレス属性

メールアドレス属性は今回のアプリに関して、必ずしも必要ではない。しかしながら、先のユーザセッション特定用のペアのみを利用する場合、ブラウザ側がセッションIDを忘れた場合、もはや元のペアを特定することができないため、新規のペアをレコードとして作成することになる。つまり、一人のユーザに対してセッションを特定するためのレコードがいくつも作成されることになる。しかし、ユーザセッションは一人のユーザに対して一つあればそれで十分である。そのため、ユーザを特定する情報として、ユーザのメールアドレスを保持しておく。これにより、ブラウザ側がセッションIDを忘れて再ログインすることになったとしても、その際に提供されるであろうメールアドレスを利用することで、各ユーザ用のユーザセッションのレコードを特定可能である。

# 補足

本PRは #4 の後続である。