### PR TITLE
RDBをバックエンドとしたセッションストアに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '3.2.2'
 
 gem 'rails', '~> 7.0.6'
 
+gem 'activerecord-session_store', '~> 2.0'
 gem 'flexirest', '~> 1.11'
 gem 'pg', '~> 1.5'
 gem 'puma', '~> 6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,12 @@ GEM
     activerecord (7.0.6)
       activemodel (= 7.0.6)
       activesupport (= 7.0.6)
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
     activestorage (7.0.6)
       actionpack (= 7.0.6)
       activejob (= 7.0.6)
@@ -316,6 +322,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-session_store (~> 2.0)
   brakeman (~> 6.0)
   capybara (~> 3.39)
   debug

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.config.session_store :active_record_store, key: '_my_app_session'

--- a/db/migrate/20230718093712_add_sessions_table.rb
+++ b/db/migrate/20230718093712_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_093712) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
 
 end


### PR DESCRIPTION
# 概要

#2 での議論を経て、RDBをバックエンドとしたセッションストアを利用するように変更する。実装には、[activerecord-session_store](https://github.com/rails/activerecord-session_store)を利用する。

- 古いレコードの自動削除は、トレーニング目的のアプリでは不要と判断したため考慮しない。
- 同様に、データサイズの制約についても、ここでは考慮しない。

# 補足

本PRは #5 の後続である。