### PR TITLE
ログイン用のアクションを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,13 @@ AllCops:
     - log/**/*
     - public/**/*
 
+Metrics/MethodLength:
+  Max: 15
+  CountAsOne:
+    - 'array'
+    - 'heredoc'
+    - 'method_call'
+
 Style/EmptyMethod:
   EnforcedStyle: expanded
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,11 @@ class ApplicationController < ActionController::Base
     render file: Rails.root.join('public/500.html'), status: :internal_server_error,
            layout: false, content_type: 'text/html'
   end
+
+  # #reset_session と異なりセッションIDのみをリセットする。
+  def reset_session_id
+    except_session_id = session.to_h
+    reset_session
+    session.update except_session_id
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,4 @@ class ApplicationController < ActionController::Base
     render file: Rails.root.join('public/500.html'), status: :internal_server_error,
            layout: false, content_type: 'text/html'
   end
-
-  # #reset_session と異なりセッションIDのみをリセットする。
-  def reset_session_id
-    original_session = session.to_h
-    reset_session
-    session.update original_session
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,8 @@ class ApplicationController < ActionController::Base
 
   # #reset_session と異なりセッションIDのみをリセットする。
   def reset_session_id
-    except_session_id = session.to_h
+    original_session = session.to_h
     reset_session
-    session.update except_session_id
+    session.update original_session
   end
 end

--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -2,11 +2,12 @@
 
 module Authenticatable
   def login(access_token)
+    reset_session
     session[:access_token] = access_token
   end
 
   def logout
-    session.delete :access_token
+    reset_session
   end
 
   def logged_in?

--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Sessions
+module Authenticatable
   def login(access_token)
     session[:access_token] = access_token
   end

--- a/app/controllers/concerns/sessions.rb
+++ b/app/controllers/concerns/sessions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Sessions
+  def login(access_token)
+    session[:access_token] = access_token
+  end
+
+  def logout
+    session.delete :access_token
+  end
+
+  def logged_in?
+    session[:access_token].present?
+  end
+
+  def current_access_token
+    session[:access_token]
+  end
+end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class FilesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 class FilesController < ApplicationController
+  include Sessions
+
   def index
     # TODO: Implement the main logic.
     reset_session_id
 
-    Api::Files.all({ access_token: session[:access_token] })
+    Api::Files.all({ access_token: current_access_token })
   rescue Flexirest::HTTPClientException
     # TODO: Implement more accurate error handlings.
-    session.delete :access_token
+    logout
     redirect_to new_session_path, status: :see_other
   rescue Flexirest::HTTPServerException, Flexirest::TimeoutException, Flexirest::ConnectionFailedException
     render_internal_server_error

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -5,7 +5,7 @@ class FilesController < ApplicationController
 
   def index
     # TODO: Implement the main logic.
-    Api::Files.all({ access_token: current_access_token })
+    Api::Files.all access_token: current_access_token
   rescue Flexirest::HTTPClientException
     # TODO: Implement more accurate error handlings.
     logout

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -5,8 +5,6 @@ class FilesController < ApplicationController
 
   def index
     # TODO: Implement the main logic.
-    reset_session_id
-
     Api::Files.all({ access_token: current_access_token })
   rescue Flexirest::HTTPClientException
     # TODO: Implement more accurate error handlings.

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -2,5 +2,15 @@
 
 class FilesController < ApplicationController
   def index
+    # TODO: Implement the main logic.
+    reset_session_id
+
+    Api::Files.all({ access_token: session[:access_token] })
+  rescue Flexirest::HTTPClientException
+    # TODO: Implement more accurate error handlings.
+    session.delete :access_token
+    redirect_to new_session_path, status: :see_other
+  rescue Flexirest::HTTPServerException, Flexirest::TimeoutException, Flexirest::ConnectionFailedException
+    render_internal_server_error
   end
 end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FilesController < ApplicationController
-  include Sessions
+  include Authenticatable
 
   def index
     # TODO: Implement the main logic.

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
-  before_action :logged_in_user
+  before_action :require_not_logged_in
 
   def new
   end
@@ -31,7 +31,11 @@ class SessionsController < ApplicationController
     params.permit :email, :password
   end
 
-  def logged_in_user
-    redirect_to files_path if session[:access_token].present?
+  def require_not_logged_in
+    redirect_to files_path if logged_in?
+  end
+
+  def logged_in?
+    session[:access_token].present?
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    response = Api::AccessToken.create access_token_params.merge(grant_type: 'password', scope: 'READ WRITE')
+    response = Api::AccessToken.create access_token_params
 
     login response.access_token
     flash[:success] = 'You logged in successfully'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     flash[:success] = 'You logged in successfully'
     redirect_to files_path, status: :see_other
   rescue Flexirest::HTTPClientException => e
-    if e.result.error == 'invalid_grant'
+    if e.status == 400 && e.result.error == 'invalid_grant'
       @errors = [{ 'name' => 'email, password or both', 'reason' => 'are invalid' }]
       render 'new', status: :unprocessable_entity
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     flash[:success] = 'You logged in successfully'
     redirect_to files_path, status: :see_other
   rescue Flexirest::HTTPClientException => e
-    if e.result.error == 'invalid_request'
+    if e.result.error == 'invalid_grant'
       @errors = [{ 'name' => 'email, password or both', 'reason' => 'are invalid' }]
       render 'new', status: :unprocessable_entity
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
-  include Sessions
+  include Authenticatable
 
   before_action :require_not_logged_in
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,37 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
+  before_action :logged_in_user
+
   def new
   end
 
   def create
+    response = Api::AccessToken.create access_token_params
+                                         .transform_keys { |k| k == :email ? :username : k }
+                                         .merge(grant_type: 'password', scope: 'READ WRITE')
+
+    session[:access_token] = response.access_token
+    flash[:success] = 'You logged in successfully'
+    redirect_to files_path, status: :see_other
+  rescue Flexirest::HTTPClientException => e
+    if e.result.error == 'invalid_request'
+      @errors = [{ 'name' => 'email, password or both', 'reason' => 'are invalid' }]
+      render 'new', status: :unprocessable_entity
+    else
+      render_internal_server_error
+    end
+  rescue Flexirest::HTTPServerException, Flexirest::TimeoutException, Flexirest::ConnectionFailedException
+    render_internal_server_error
+  end
+
+  private
+
+  def access_token_params
+    params.require(:access_token).permit :email, :password
+  end
+
+  def logged_in_user
+    redirect_to files_path if session[:access_token].present?
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,9 +9,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    response = Api::AccessToken.create access_token_params
-                                         .transform_keys { |k| k == :email ? :username : k }
-                                         .merge(grant_type: 'password', scope: 'READ WRITE')
+    response = Api::AccessToken.create access_token_params.merge(grant_type: 'password', scope: 'READ WRITE')
 
     login response.access_token
     flash[:success] = 'You logged in successfully'
@@ -30,7 +28,7 @@ class SessionsController < ApplicationController
   private
 
   def access_token_params
-    params.permit :email, :password
+    params.permit :username, :password
   end
 
   def require_not_logged_in

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,7 @@ class SessionsController < ApplicationController
   private
 
   def access_token_params
-    params.require(:access_token).permit :email, :password
+    params.permit :email, :password
   end
 
   def logged_in_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
+  include Sessions
+
   before_action :require_not_logged_in
 
   def new
@@ -11,7 +13,7 @@ class SessionsController < ApplicationController
                                          .transform_keys { |k| k == :email ? :username : k }
                                          .merge(grant_type: 'password', scope: 'READ WRITE')
 
-    session[:access_token] = response.access_token
+    login response.access_token
     flash[:success] = 'You logged in successfully'
     redirect_to files_path, status: :see_other
   rescue Flexirest::HTTPClientException => e
@@ -33,9 +35,5 @@ class SessionsController < ApplicationController
 
   def require_not_logged_in
     redirect_to files_path if logged_in?
-  end
-
-  def logged_in?
-    session[:access_token].present?
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,4 +3,7 @@
 class SessionsController < ApplicationController
   def new
   end
+
+  def create
+  end
 end

--- a/app/models/api/access_token.rb
+++ b/app/models/api/access_token.rb
@@ -2,6 +2,6 @@
 
 module Api
   class AccessToken < Flexirest::Base
-    post :create, '/signin'
+    post :create, '/signin', defaults: { grant_type: 'password', scope: 'READ WRITE' }
   end
 end

--- a/app/models/api/access_token.rb
+++ b/app/models/api/access_token.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Api
+  class AccessToken < Flexirest::Base
+    post :create, '/signin'
+  end
+end

--- a/app/models/api/files.rb
+++ b/app/models/api/files.rb
@@ -7,7 +7,7 @@ module Api
     before_request do |name, request|
       if name == :all
         access_token = request.get_params.delete :access_token
-        request.headers['Authorization'] = "Bearer: #{access_token}"
+        request.headers['Authorization'] = "Bearer #{access_token}"
       end
     end
   end

--- a/app/models/api/files.rb
+++ b/app/models/api/files.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  class Files < Flexirest::Base
+    get :all, '/files'
+
+    before_request do |name, request|
+      if name == :all
+        access_token = request.get_params.delete :access_token
+        request.headers['Authorization'] = "Bearer: #{access_token}"
+      end
+    end
+  end
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for :access_token, url: sessions_path do |f| %>
+<%= form_with url: sessions_path do |f| %>
   <%= render 'shared/error_messages', errors: @errors %>
 
   <%= f.label :email %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,8 +1,8 @@
 <%= form_with url: sessions_path do |f| %>
   <%= render 'shared/error_messages', errors: @errors %>
 
-  <%= f.label :email %>
-  <%= f.email_field :email %>
+  <%= f.label :username, 'Email' %>
+  <%= f.email_field :username %>
 
   <%= f.label :password %>
   <%= f.password_field :password %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,11 @@
+<%= form_for :access_token, url: sessions_path do |f| %>
+  <%= render 'shared/error_messages', errors: @errors %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+
+  <%= f.submit 'Log in' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  resources :sessions, only: %i[new]
+  resources :sessions, only: %i[new create]
   resources :users, only: %i[new create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :files, only: %i[index]
   resources :sessions, only: %i[new create]
   resources :users, only: %i[new create]
 end

--- a/spec/system/session_creation_spec.rb
+++ b/spec/system/session_creation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Session Creation', type: :system do
     context 'フォームへの入力が全て正当であるとき' do
       context 'APIサーバから成功レスポンスが返ってきたとき' do
         before do
-          WebMock.stub_request(:post, "#{Api::User.base_url}/signin")
+          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin'))
             .to_return(
               body:    {
                 access_token: 'some_token',
@@ -29,7 +29,7 @@ RSpec.describe 'Session Creation', type: :system do
               status:  200,
               headers: { 'Content-Type' => 'application/json' }
             )
-          WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+          WebMock.stub_request(:get, File.join(Api::User.base_url, 'files')).to_return(
             body:    '{}',
             status:  200,
             headers: { 'Content-Type' => 'application/json' }
@@ -47,8 +47,8 @@ RSpec.describe 'Session Creation', type: :system do
 
       context 'APIサーバからエラーレスポンスが返ってきたとき' do
         before do
-          WebMock.stub_request(:post, "#{Api::User.base_url}/signin").to_return status: 500
-          WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return status: 500
+          WebMock.stub_request(:get, File.join(Api::User.base_url, 'files')).to_return(
             body:    '{}',
             status:  200,
             headers: { 'Content-Type' => 'application/json' }
@@ -67,7 +67,7 @@ RSpec.describe 'Session Creation', type: :system do
         let(:password) { nil }
 
         before do
-          WebMock.stub_request(:post, "#{Api::User.base_url}/signin").to_return(
+          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
             body:    {
               status: 400,
               title:  'Bad Request',
@@ -106,7 +106,7 @@ RSpec.describe 'Session Creation', type: :system do
 
     context 'セッションが無効であるとき' do
       before do
-        WebMock.stub_request(:post, "#{Api::User.base_url}/signin").to_return(
+        WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
           body:    {
             access_token: 'some_token',
             token_type:   'bearer'
@@ -114,7 +114,7 @@ RSpec.describe 'Session Creation', type: :system do
           status:  200,
           headers: { 'Content-Type' => 'application/json' }
         )
-        WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+        WebMock.stub_request(:get, File.join(Api::User.base_url, 'files')).to_return(
           body:    {
             status: 401,
             title:  'Unauthorized',
@@ -138,7 +138,7 @@ RSpec.describe 'Session Creation', type: :system do
 
     context 'セッションが有効であるとき' do
       before do
-        WebMock.stub_request(:post, "#{Api::User.base_url}/signin").to_return(
+        WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
           body:    {
             access_token: 'some_token',
             token_type:   'bearer'
@@ -146,7 +146,7 @@ RSpec.describe 'Session Creation', type: :system do
           status:  200,
           headers: { 'Content-Type' => 'application/json' }
         )
-        WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+        WebMock.stub_request(:get, File.join(Api::User.base_url, 'files')).to_return(
           body:    '{}',
           status:  200,
           headers: { 'Content-Type' => 'application/json' }

--- a/spec/system/session_creation_spec.rb
+++ b/spec/system/session_creation_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Session Creation', type: :system do
+  context '未ログインであるとき' do
+    subject do
+      visit new_session_url
+
+      fill_in 'Email', with: email
+      fill_in 'Password', with: password
+      click_button 'Log in'
+
+      page
+    end
+
+    let(:email) { Faker::Internet.email }
+    let(:password) { Faker::Internet.password }
+
+    context 'フォームへの入力が全て正当であるとき' do
+      context 'APIサーバから成功レスポンスが返ってきたとき' do
+        before do
+          WebMock.stub_request(:post, "#{Api::User.base_url}/signin")
+            .to_return(
+              body:    {
+                access_token: 'some_token',
+                token_type:   'bearer'
+              }.to_json,
+              status:  200,
+              headers: { 'Content-Type' => 'application/json' }
+            )
+          WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+            body:    '{}',
+            status:  200,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+        end
+
+        it 'ファイル一覧表示用のURLにリダイレクトする' do
+          expect(subject).to have_current_path files_path
+        end
+
+        it 'ログインに成功した旨を示すメッセージが表示される' do
+          expect(subject).to have_content 'You logged in successfully'
+        end
+      end
+
+      context 'APIサーバからエラーレスポンスが返ってきたとき' do
+        before do
+          WebMock.stub_request(:post, "#{Api::User.base_url}/signin").to_return status: 500
+          WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+            body:    '{}',
+            status:  200,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+        end
+
+        it '500エラー用のページを表示する' do
+          expect(subject).to have_content 'sorry'
+        end
+      end
+    end
+
+    context 'フォームへの入力に不正があるとき' do
+      context '各フォームへの入力が空であるとき' do
+        let(:email) { nil }
+        let(:password) { nil }
+
+        before do
+          WebMock.stub_request(:post, "#{Api::User.base_url}/signin").to_return(
+            body:    {
+              status: 400,
+              title:  'Bad Request',
+              error:  'invalid_request'
+            }.to_json,
+            status:  400,
+            headers: { 'Content-Type' => 'application/problem+json' }
+          )
+          WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+            body:    '{}',
+            status:  200,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+        end
+
+        it 'サインイン用のページを表示する' do
+          subject
+
+          expect(page).to have_field 'Email'
+          expect(page).to have_field 'Password'
+        end
+
+        it '送信した値が正しくない旨が表示される' do
+          expect(subject).to have_content 'email, password or both are invalid'
+        end
+      end
+    end
+  end
+
+  context 'ログイン済みであるとき' do
+    subject do
+      visit new_session_url
+
+      page
+    end
+
+    context 'セッションが無効であるとき' do
+      before do
+        WebMock.stub_request(:post, "#{Api::User.base_url}/signin").to_return(
+          body:    {
+            access_token: 'some_token',
+            token_type:   'bearer'
+          }.to_json,
+          status:  200,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+          body:    {
+            status: 401,
+            title:  'Unauthorized',
+            error:  'invalid_token'
+          }.to_json,
+          status:  401,
+          headers: { 'Content-Type' => 'application/problem+json' }
+        )
+
+        visit new_session_url
+
+        fill_in 'Email', with: Faker::Internet.email
+        fill_in 'Password', with: Faker::Internet.password
+        click_button 'Log in'
+      end
+
+      it 'ログイン用のURLにリダイレクトする' do
+        expect(subject).to have_current_path new_session_url
+      end
+    end
+
+    context 'セッションが有効であるとき' do
+      before do
+        WebMock.stub_request(:post, "#{Api::User.base_url}/signin").to_return(
+          body:    {
+            access_token: 'some_token',
+            token_type:   'bearer'
+          }.to_json,
+          status:  200,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
+          body:    '{}',
+          status:  200,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+        visit new_session_url
+
+        fill_in 'Email', with: Faker::Internet.email
+        fill_in 'Password', with: Faker::Internet.password
+        click_button 'Log in'
+      end
+
+      it 'ファイル一覧表示用のURLにリダイレクトする' do
+        expect(subject).to have_current_path files_path
+      end
+    end
+  end
+end

--- a/spec/system/session_creation_spec.rb
+++ b/spec/system/session_creation_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Session Creation', type: :system do
               body:    {
                 status: 400,
                 title:  'Bad Request',
-                error:  'invalid_request'
+                error:  'invalid_grant'
               }.to_json,
               status:  400,
               headers: { 'Content-Type' => 'application/problem+json' }

--- a/spec/system/session_creation_spec.rb
+++ b/spec/system/session_creation_spec.rb
@@ -20,15 +20,14 @@ RSpec.describe 'Session Creation', type: :system do
     context 'フォームへの入力が全て正当であるとき' do
       context 'APIサーバから成功レスポンスが返ってきたとき' do
         before do
-          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin'))
-            .to_return(
-              body:    {
-                access_token: 'some_token',
-                token_type:   'bearer'
-              }.to_json,
-              status:  200,
-              headers: { 'Content-Type' => 'application/json' }
-            )
+          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
+            body:    {
+              access_token: 'some_token',
+              token_type:   'bearer'
+            }.to_json,
+            status:  200,
+            headers: { 'Content-Type' => 'application/json' }
+          )
           WebMock.stub_request(:get, File.join(Api::User.base_url, 'files')).to_return(
             body:    '{}',
             status:  200,

--- a/spec/system/session_creation_spec.rb
+++ b/spec/system/session_creation_spec.rb
@@ -81,10 +81,7 @@ RSpec.describe 'Session Creation', type: :system do
     end
 
     context 'フォームへの入力に不正があるとき' do
-      context '各フォームへの入力が空文字列であるとき' do
-        let(:email) { '' }
-        let(:password) { '' }
-
+      context '各フォームへの入力が不正なROPCグラント(メールアドレス、パスワード)であるとき' do
         before do
           WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin'))
             .with(

--- a/spec/system/session_creation_spec.rb
+++ b/spec/system/session_creation_spec.rb
@@ -47,11 +47,6 @@ RSpec.describe 'Session Creation', type: :system do
       context 'APIサーバからエラーレスポンスが返ってきたとき' do
         before do
           WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return status: 500
-          WebMock.stub_request(:get, File.join(Api::User.base_url, 'files')).to_return(
-            body:    '{}',
-            status:  200,
-            headers: { 'Content-Type' => 'application/json' }
-          )
         end
 
         it '500エラー用のページを表示する' do
@@ -74,11 +69,6 @@ RSpec.describe 'Session Creation', type: :system do
             }.to_json,
             status:  400,
             headers: { 'Content-Type' => 'application/problem+json' }
-          )
-          WebMock.stub_request(:get, "#{Api::User.base_url}/files").to_return(
-            body:    '{}',
-            status:  200,
-            headers: { 'Content-Type' => 'application/json' }
           )
         end
 


### PR DESCRIPTION
# 概要

ユーザのフォーム入力を経てAPIサーバに送信し、アクセストークンを発行するアクションを追加する。

- 発行したアクセストークンはRDBをバックエンドとしたセッションストアに保存する。
- ファイル一覧表示用のアクションも同時に実装しているが、これはログイン済みの場合のリダイレクト先として利用しているためである。また、本PRで必要な範囲の機能のみを実装しており、メインのロジックやテストは、別PRで扱う予定である。

# 補足

本PRは #6 の後続である。