### PR TITLE
`#form_with` を使ってフォームを構築する

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,11 +21,11 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit :name, :email, :password
+    params.permit :name, :email, :password
   end
 
   def confirm_password
-    return if params.dig(:user, :password) == params.dig(:user, :password_confirmation)
+    return if params[:password] == params[:password_confirmation]
 
     @errors = [{ 'name' => 'password_confirmation', 'reason' => "doesn't match with password" }]
     render 'new', status: :unprocessable_entity

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for :user, url: users_path do |f| %>
+<%= form_with url: users_path do |f| %>
   <%= render 'shared/error_messages', errors: @errors %>
 
   <%= f.label :name %>


### PR DESCRIPTION
# 概要

https://github.com/sls-training/2023-API-training-client/pull/7#discussion_r1267897739 での指摘を受けて、 `#form_for` ではなく、 `#form_with` を使ってフォームを構築するように変更する。