### PR TITLE
ファイル一覧表示用のアクションの追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,9 @@ Style/EmptyMethod:
 RSpec/MultipleExpectations:
   Max: 10
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
 RSpec/NestedGroups:
   Max: 4
   Include:

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rails', '~> 7.0.6'
 
 gem 'activerecord-session_store', '~> 2.0'
 gem 'flexirest', '~> 1.11'
+gem 'link-header-parser', '~> 5.0'
 gem 'pg', '~> 1.5'
 gem 'puma', '~> 6.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
       reline (>= 0.3.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    link-header-parser (5.0.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -330,6 +331,7 @@ DEPENDENCIES
   faker (~> 3.2)
   flexirest (~> 1.11)
   katakata_irb!
+  link-header-parser (~> 5.0)
   pg (~> 1.5)
   puma (~> 6.3)
   rails (~> 7.0.6)

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Paginatable
+  def pagination_links(link_header_value, base:)
+    return {} if link_header_value.blank?
+
+    LinkHeaderParser.parse(link_header_value, base:)
+      .group_by_relation_type
+      .slice(:first, :last, :prev, :next)
+      .transform_values { |a| a.first&.target_uri }
+  end
+end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -11,14 +11,11 @@ class FilesController < ApplicationController
 
     @files = index_files_response[:files]
     @pagination_metadata = pagination_metadata index_files_response._headers
-  rescue Flexirest::HTTPClientException => e
-    if e.status == 401 && e.result&.error == 'invalid_token'
-      logout
-      redirect_to new_session_path, status: :see_other
-    else
-      render_internal_server_error
-    end
-  rescue Flexirest::HTTPServerException, Flexirest::TimeoutException, Flexirest::ConnectionFailedException
+  rescue Flexirest::HTTPUnauthorisedClientException
+    logout
+    redirect_to new_session_path, status: :see_other
+  rescue Flexirest::HTTPClientException, Flexirest::HTTPServerException,
+         Flexirest::TimeoutException, Flexirest::ConnectionFailedException
     render_internal_server_error
   end
 

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -9,10 +9,13 @@ class FilesController < ApplicationController
     response = Api::Files.all access_token: current_access_token
 
     @files = response[:files]
-  rescue Flexirest::HTTPClientException
-    # TODO: Implement more accurate error handlings.
-    logout
-    redirect_to new_session_path, status: :see_other
+  rescue Flexirest::HTTPClientException => e
+    if e.status == 401 && e.result&.error == 'invalid_token'
+      logout
+      redirect_to new_session_path, status: :see_other
+    else
+      render_internal_server_error
+    end
   rescue Flexirest::HTTPServerException, Flexirest::TimeoutException, Flexirest::ConnectionFailedException
     render_internal_server_error
   end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -6,9 +6,9 @@ class FilesController < ApplicationController
   before_action :require_login
 
   def index
-    response = Api::Files.all access_token: current_access_token
+    index_files_response = Api::Files.all access_token: current_access_token
 
-    @files = response[:files]
+    @files = index_files_response[:files]
   rescue Flexirest::HTTPClientException => e
     if e.status == 401 && e.result&.error == 'invalid_token'
       logout

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -3,14 +3,23 @@
 class FilesController < ApplicationController
   include Authenticatable
 
+  before_action :require_login
+
   def index
-    # TODO: Implement the main logic.
-    Api::Files.all access_token: current_access_token
+    response = Api::Files.all access_token: current_access_token
+
+    @files = response[:files]
   rescue Flexirest::HTTPClientException
     # TODO: Implement more accurate error handlings.
     logout
     redirect_to new_session_path, status: :see_other
   rescue Flexirest::HTTPServerException, Flexirest::TimeoutException, Flexirest::ConnectionFailedException
     render_internal_server_error
+  end
+
+  private
+
+  def require_login
+    redirect_to new_session_path unless logged_in?
   end
 end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PaginationHelper
-  def pagination_entires_info(**metadata)
+  def pagination_entries_info(**metadata)
     total = metadata[:total]
     page = metadata[:page]
     per = metadata[:per]

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PaginationHelper
+  def pagination_entires_info(**metadata)
+    total = metadata[:total]
+    page = metadata[:page]
+    per = metadata[:per]
+
+    first_idx_in_page = total.positive? ? 1 + page.pred * per : 0
+    last_idx_in_page = (first_idx_in_page + per.pred).then { |n| n > total ? total : n }
+
+    "Displaying items #{first_idx_in_page} - #{last_idx_in_page} of #{total} in total"
+  end
+end

--- a/app/views/files/_file.html.erb
+++ b/app/views/files/_file.html.erb
@@ -1,0 +1,7 @@
+<tr>
+  <%= content_tag :td, file[:id] %>
+  <%= content_tag :td, file[:name] %>
+  <%= content_tag :td, file[:size] %>
+  <%= content_tag :td, file[:created_at] %>
+  <%= content_tag :td, file[:changed_at] %>
+</tr>

--- a/app/views/files/_files.html.erb
+++ b/app/views/files/_files.html.erb
@@ -1,0 +1,14 @@
+<table>
+  <thead>
+    <tr>
+      <th>id</th>
+      <th>name</th>
+      <th>size</th>
+      <th>created_at</th>
+      <th>changed_at</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'file', collection: files %>
+  </tbody>
+</table>

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= render 'shared/pagination_entires_info', total: @pagination_metadata[:total], page: @pagination_metadata[:page], per: @pagination_metadata[:per] %>
+  <%= render 'shared/pagination_entries_info', total: @pagination_metadata[:total], page: @pagination_metadata[:page], per: @pagination_metadata[:per] %>
 
   <div>
     <%= render 'files', files: @files %>

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -1,3 +1,9 @@
 <div>
-  <%= render 'files', files: @files %>
+  <%= render 'shared/pagination_entires_info', total: @pagination_metadata[:total], page: @pagination_metadata[:page], per: @pagination_metadata[:per] %>
+
+  <div>
+    <%= render 'files', files: @files %>
+  </div>
+
+  <%= render 'shared/pagination', links: @pagination_metadata[:links] %>
 </div>

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= render 'files', files: @files %>
+</div>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <% if links[:first].present? %>
+    <%= link_to 'First', links[:first] %>
+  <% end %>
+
+  <% if links[:prev].present? %>
+    <%= link_to 'Prev', links[:prev] %>
+  <% end %>
+
+  <% if links[:next].present? %>
+    <%= link_to 'Next', links[:next] %>
+  <% end %>
+
+  <% if links[:last].present? %>
+    <%= link_to 'Last', links[:last] %>
+  <% end %>
+</div

--- a/app/views/shared/_pagination_entires_info.html.erb
+++ b/app/views/shared/_pagination_entires_info.html.erb
@@ -1,3 +1,0 @@
-<div>
-  <%= pagination_entires_info(total:, page:, per:) %>
-</div>

--- a/app/views/shared/_pagination_entires_info.html.erb
+++ b/app/views/shared/_pagination_entires_info.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= pagination_entires_info(total:, page:, per:) %>
+</div>

--- a/app/views/shared/_pagination_entries_info.html.erb
+++ b/app/views/shared/_pagination_entries_info.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= pagination_entries_info(total:, page:, per:) %>
+</div>

--- a/spec/system/files_index_spec.rb
+++ b/spec/system/files_index_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Files Index', type: :system do
+  subject do
+    visit files_url
+
+    page
+  end
+
+  context '未ログインであるとき' do
+    it 'ログインページにリダイレクトする' do
+      expect(subject).to have_current_path new_session_url
+    end
+  end
+
+  context 'ログイン済みであるとき' do
+    let(:access_token) { Faker::Alphanumeric.alphanumeric }
+
+    context 'セッションが無効であるとき' do
+      before do
+        WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
+          body:    {
+            access_token:,
+            token_type:   'bearer'
+          }.to_json,
+          status:  200,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        WebMock.stub_request(:get, File.join(Api::User.base_url, 'files'))
+          .with(
+            headers: {
+              Authorization: "Bearer #{access_token}"
+            }
+          )
+          .to_return(
+            body:    {
+              status: 401,
+              title:  'Unauthorized',
+              error:  'invalid_token'
+            }.to_json,
+            status:  401,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        visit new_session_url
+
+        fill_in 'Email', with: Faker::Internet.email
+        fill_in 'Password', with: Faker::Internet.password
+
+        click_button 'Log in'
+      end
+
+      it 'ログインページにリダイレクトする' do
+        expect(subject).to have_current_path new_session_url
+      end
+    end
+
+    context 'セッションが有効であるとき' do
+      context 'APIサーバから成功レスポンスが返ってきたとき' do
+        let(:files) do
+          [
+            {
+              id:          '76DA18B4-7CF0-48C1-A33D-2FFA0A4B345A',
+              name:        'sample01.txt',
+              description: 'My diary',
+              size:        1024,
+              created_at:  '2020-10-12T11:20:44+00:00',
+              changed_at:  '2023-05-25T23:07:39+00:00'
+            },
+            {
+              id:         '9BD3BEA3-67E7-401A-9A45-C6CAB38A052A',
+              name:       'sample02.png',
+              size:       1_048_576,
+              created_at: '2020-10-12T11:10:30+00:00',
+              changed_at: '2020-10-12T11:10:30+00:00'
+            }
+          ]
+        end
+
+        before do
+          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
+            body:    {
+              access_token:,
+              token_type:   'bearer'
+            }.to_json,
+            status:  200,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          WebMock.stub_request(:get, File.join(Api::User.base_url, 'files'))
+            .with(
+              headers: {
+                Authorization: "Bearer #{access_token}"
+              }
+            )
+            .to_return(
+              body:    { files: }.to_json,
+              status:  200,
+              headers: { 'Content-Type' => 'application/json' }
+            )
+
+          visit new_session_url
+
+          fill_in 'Email', with: Faker::Internet.email
+          fill_in 'Password', with: Faker::Internet.password
+
+          click_button 'Log in'
+        end
+
+        it 'ファイル一覧が表示される' do
+          subject
+
+          expect(page).to have_content files[0][:name]
+          expect(page).to have_content files[1][:name]
+        end
+      end
+
+      context 'APIサーバからエラーレスポンスが返ってきたとき' do
+        before do
+          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
+            body:    {
+              access_token:,
+              token_type:   'bearer'
+            }.to_json,
+            status:  200,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          WebMock.stub_request(:get, File.join(Api::User.base_url, 'files'))
+            .with(
+              headers: {
+                Authorization: "Bearer #{access_token}"
+              }
+            )
+            .to_return(
+              body:    '{}',
+              status:  500,
+              headers: { 'Content-Type' => 'application/json' }
+            )
+
+          visit new_session_url
+
+          fill_in 'Email', with: Faker::Internet.email
+          fill_in 'Password', with: Faker::Internet.password
+
+          click_button 'Log in'
+        end
+
+        it '500用のページが表示される' do
+          expect(subject).to have_content 'sorry'
+        end
+      end
+    end
+  end
+end

--- a/spec/system/files_index_spec.rb
+++ b/spec/system/files_index_spec.rb
@@ -18,16 +18,31 @@ RSpec.describe 'Files Index', type: :system do
   context 'ログイン済みであるとき' do
     let(:access_token) { Faker::Alphanumeric.alphanumeric }
 
+    before do
+      WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
+        body:    {
+          access_token:,
+          token_type:   'bearer'
+        }.to_json,
+        status:  200,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+      WebMock.stub_request(:get, File.join(Api::User.base_url, 'files')).with(
+        headers: {
+          Authorization: "Bearer #{access_token}"
+        }
+      )
+
+      visit new_session_url
+
+      fill_in 'Email', with: Faker::Internet.email
+      fill_in 'Password', with: Faker::Internet.password
+
+      click_button 'Log in'
+    end
+
     context 'セッションが無効であるとき' do
       before do
-        WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
-          body:    {
-            access_token:,
-            token_type:   'bearer'
-          }.to_json,
-          status:  200,
-          headers: { 'Content-Type' => 'application/json' }
-        )
         WebMock.stub_request(:get, File.join(Api::User.base_url, 'files'))
           .with(
             headers: {
@@ -43,13 +58,6 @@ RSpec.describe 'Files Index', type: :system do
             status:  401,
             headers: { 'Content-Type' => 'application/json' }
           )
-
-        visit new_session_url
-
-        fill_in 'Email', with: Faker::Internet.email
-        fill_in 'Password', with: Faker::Internet.password
-
-        click_button 'Log in'
       end
 
       it 'ログインページにリダイレクトする' do
@@ -80,14 +88,6 @@ RSpec.describe 'Files Index', type: :system do
         end
 
         before do
-          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
-            body:    {
-              access_token:,
-              token_type:   'bearer'
-            }.to_json,
-            status:  200,
-            headers: { 'Content-Type' => 'application/json' }
-          )
           WebMock.stub_request(:get, File.join(Api::User.base_url, 'files'))
             .with(
               headers: {
@@ -99,13 +99,6 @@ RSpec.describe 'Files Index', type: :system do
               status:  200,
               headers: { 'Content-Type' => 'application/json' }
             )
-
-          visit new_session_url
-
-          fill_in 'Email', with: Faker::Internet.email
-          fill_in 'Password', with: Faker::Internet.password
-
-          click_button 'Log in'
         end
 
         it 'ファイル一覧が表示される' do
@@ -118,14 +111,6 @@ RSpec.describe 'Files Index', type: :system do
 
       context 'APIサーバからエラーレスポンスが返ってきたとき' do
         before do
-          WebMock.stub_request(:post, File.join(Api::User.base_url, 'signin')).to_return(
-            body:    {
-              access_token:,
-              token_type:   'bearer'
-            }.to_json,
-            status:  200,
-            headers: { 'Content-Type' => 'application/json' }
-          )
           WebMock.stub_request(:get, File.join(Api::User.base_url, 'files'))
             .with(
               headers: {
@@ -137,13 +122,6 @@ RSpec.describe 'Files Index', type: :system do
               status:  500,
               headers: { 'Content-Type' => 'application/json' }
             )
-
-          visit new_session_url
-
-          fill_in 'Email', with: Faker::Internet.email
-          fill_in 'Password', with: Faker::Internet.password
-
-          click_button 'Log in'
         end
 
         it '500用のページが表示される' do


### PR DESCRIPTION
# 概要

APIサーバの `/files` リソースにGETリクエストを投げてレスポンスに含まれているアップロード済みのファイル一覧のメタデータを表示する。

その際のレスポンスには、ヘッダーには、総ファイル件数や現在のページ番号のような、ページネーションに関するメタデータが含まれているため、それらの情報を利用して、ページネーション用のリンクや現在のページに含まれてるファイルの位置情報などを表示する。

なお、HTMLには必要な情報が表示されていれば問題ない程度の認識で書いてあるので、大変大雑把な内容になっている。