### PR TITLE
リクエスト時のエラーハンドリング用のクラスを4XX用から400用に変更

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,14 +14,15 @@ class SessionsController < ApplicationController
     login response.access_token
     flash[:success] = 'You logged in successfully'
     redirect_to files_path, status: :see_other
-  rescue Flexirest::HTTPClientException => e
-    if e.status == 400 && e.result.error == 'invalid_grant'
+  rescue Flexirest::HTTPBadRequestClientException => e
+    if e.result.error == 'invalid_grant'
       @errors = [{ 'name' => 'email, password or both', 'reason' => 'are invalid' }]
       render 'new', status: :unprocessable_entity
     else
       render_internal_server_error
     end
-  rescue Flexirest::HTTPServerException, Flexirest::TimeoutException, Flexirest::ConnectionFailedException
+  rescue Flexirest::HTTPClientException, Flexirest::HTTPServerException,
+         Flexirest::TimeoutException, Flexirest::ConnectionFailedException
     render_internal_server_error
   end
 


### PR DESCRIPTION
# 概要

APIへのリクエスト時のエラーハンドリング用のクラスを、クライアントエラー(4XX)を扱うクラスから、より具体的な400 Bad Request用のクラスに変更する。これにより、コード内で直接ステータスコードを検証する必要がなくなる。